### PR TITLE
Sign In 

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Heroku-dat-template
 
 ### A simple Heroku app template for deploying [Dat](http://github.com/maxogden/dat)
 
-Deploy a dat on the Heroku [Ephemeral Filesystem](https://devcenter.heroku.com/articles/dynos#ephemeral-filesystem) (data will be **temporary**):
+Deploy a dat on the Heroku. [Ephemeral Filesystem](https://devcenter.heroku.com/articles/dynos#ephemeral-filesystem) (data will be **temporary**). Sign in after spinning up app:
 
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/bmpvieira/heroku-dat-template.git)
 


### PR DESCRIPTION
Think it would be helpful to tell users to sign in after they have spun up Heroku app.

When I initially tried to import data into the Heroku interface I got this error:

Error: {"error":"missing or unsupported content-type","status":400}

It did not take me long to figure out that I needed to sign in before importing json or a csv file, however I feel it would be helpful if we pointed out in the documentation to sign in before interacting with the Heroku app.
