### PR TITLE
Keep dat alive on heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: dat listen

--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ _Note: Only tabular data is stored in postgres/redis. Blobs will still be stored
 
 Environment Variables
 -----
-During deploy you will be asked to provide values for 3 environment variables.
+During deploy you will be asked to provide values for the following environment variables.
 
 * `DEBUG` - enter `*` to enable debug logging info to show up in `heroku logs`
 * `DAT_ADMIN_USER` and `DAT_ADMIN_PASS` - these make dat read-only for anonymous users
+* `HEROKU_URL` set this to your heroku app url, so it can self ping itself to not be spinned down
 
 Usage
 -----

--- a/app.json
+++ b/app.json
@@ -14,6 +14,7 @@
   "env": {
     "DEBUG": "false",
     "DAT_ADMIN_USER": "admin",
-    "DAT_ADMIN_PASS": ""
+    "DAT_ADMIN_PASS": "",
+    "HEROKU_URL": "http://<appname>.herokuapp.com"
   }
 }

--- a/dat.json
+++ b/dat.json
@@ -1,0 +1,5 @@
+{
+  "hooks": {
+    "listen": "./ping.js"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "version": "0.0.1",
   "description": "Dat server template for Heroku",
   "dependencies": {
-    "dat": "^6.3.3"
+    "dat": "^6.3.3",
+    "heroku-self-ping": "^1.1.1"
   },
   "devDependencies": {},
   "scripts": {
-    "postinstall": "dat init --no-prompt"
+    "postinstall": "dat init --no-prompt",
+    "start": "dat listen"
   },
   "keywords": [
     "dat",

--- a/ping.js
+++ b/ping.js
@@ -1,0 +1,4 @@
+module.exports = function (dat, ready) {
+  ready()
+  require('heroku-self-ping')(process.env.HEROKU_URL)
+}


### PR DESCRIPTION
This PR adds a listen hook to self ping the heroku instance. This makes sure it doesn't get spinned down on heroku (which results in data loss).  I tested this on heroku and it works fine.

I also removed the Procfile, because heroku is able to detect `npm start` just fine.
